### PR TITLE
Improve theme toggle visuals

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40">
+  <rect width="100" height="40" rx="8" fill="#ffffff"/>
+  <text x="50" y="27" font-family="Arial, sans-serif" font-size="24" fill="#000000" text-anchor="middle">OM</text>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,7 @@
 }
 
 body.light {
+  --primary-color: #f7b500;
   --secondary-color: #ffffff;
   --text-color: #000000;
   --nav-text-color: #000000;
@@ -30,9 +31,10 @@ body.light {
 
 
 body.dark {
+  --primary-color: #333333;
   --secondary-color: #000000;
   --text-color: #ffffff;
-  --nav-text-color: #000000;
+  --nav-text-color: #ffffff;
   --title-color: #ffffff;
   --subtitle-color: #cccccc;
   --footer-text-color: #000000;
@@ -87,6 +89,53 @@ body, html {
   margin-left: 1rem;
   cursor: pointer;
   transition: color 0.3s;
+}
+
+
+.nav .theme-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  margin-left: 1rem;
+}
+
+.nav .theme-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.nav .theme-switch .slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: background-color 0.3s;
+  border-radius: 20px;
+}
+
+.nav .theme-switch .slider:before {
+  position: absolute;
+  content: '';
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: transform 0.3s;
+  border-radius: 50%;
+}
+
+.nav .theme-switch input:checked + .slider {
+  background-color: var(--accent-color);
+}
+
+.nav .theme-switch input:checked + .slider:before {
+  transform: translateX(20px);
 }
 
 .nav .nav-link.active,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,12 +32,14 @@ function App() {
           >
             Envío
           </button>
-          <button
-            className="nav-link"
-            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-          >
-            {theme === 'dark' ? 'Modo claro' : 'Modo oscuro'}
-          </button>
+          <label className="theme-switch">
+            <input
+              type="checkbox"
+              checked={theme === 'dark'}
+              onChange={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            />
+            <span className="slider" />
+          </label>
         </nav>
       </header>
 


### PR DESCRIPTION
## Summary
- adjust light/dark color variables so the header changes with the theme
- add simple logo asset
- show sun/moon icons next to theme toggle button
- replace toggle icons with slider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6845fb50f88483298bba2aaf9d00dfc1