### PR TITLE
Add success message to editor and enlarge header logo

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,7 +76,7 @@ body, html {
 }
 
 .logo img {
-  height: 40px;
+  height: 80px;
 }
 
 .nav .nav-link {

--- a/src/components/EditorSection.css
+++ b/src/components/EditorSection.css
@@ -87,3 +87,26 @@
     transform: rotate(360deg);
   }
 }
+
+.success-message {
+  margin-top: 1rem;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+  font-size: 1rem;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  animation: fadeInOut 5s ease-in-out forwards;
+  opacity: 0;
+}
+
+@keyframes fadeInOut {
+  0% { opacity: 0; transform: translateY(-20px); }
+  10% { opacity: 1; transform: translateY(0); }
+  90% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-20px); }
+}

--- a/src/components/EditorSection.tsx
+++ b/src/components/EditorSection.tsx
@@ -4,6 +4,7 @@ import './EditorSection.css';
 function EditorSection() {
   const [file, setFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -23,6 +24,7 @@ function EditorSection() {
     setLoading(true);
     setTimeout(() => {
       setLoading(false);
+      setShowSuccess(true);
       const blob = new Blob(['Contenido ficticio ZIP'], { type: 'application/zip' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -30,6 +32,7 @@ function EditorSection() {
       a.download = 'resultado.zip';
       a.click();
       URL.revokeObjectURL(url);
+      setTimeout(() => setShowSuccess(false), 7000);
     }, 3000);
   };
 
@@ -67,6 +70,11 @@ function EditorSection() {
             'Editar'
         )}
         </button>
+      {showSuccess && (
+        <div className="success-message">
+          ✅ Las imágenes se han editado exitosamente
+        </div>
+      )}
 
     </div>
   );


### PR DESCRIPTION
## Summary
- enlarge header logo for better visibility
- show success message after editing images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684604d879c0832995979e2634374ac3