### PR TITLE
Improve success message styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/png" href="./favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Edition Orla Magna</title>
   </head>

--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,8 @@
   --button-text-color: #000000;
   --button-disabled-bg: rgba(255, 255, 255, 0.2);
   --button-disabled-text-color: #aaaaaa;
+  --success-bg-color: #4caf50;
+  --success-text-color: #ffffff;
 }
 
 body.light {

--- a/src/components/EditorSection.css
+++ b/src/components/EditorSection.css
@@ -100,8 +100,8 @@
 
 .success-message {
   margin-top: 1rem;
-  background-color: var(--primary-color);
-  color: var(--secondary-color);
+  background-color: var(--success-bg-color);
+  color: var(--success-text-color);
   padding: 1rem 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.2);

--- a/src/components/EnvioSection.css
+++ b/src/components/EnvioSection.css
@@ -100,8 +100,8 @@
 
 .success-message {
   margin-top: 1rem;
-  background-color: var(--primary-color);
-  color: var(--secondary-color);
+  background-color: var(--success-bg-color);
+  color: var(--success-text-color);
   padding: 1rem 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.2);


### PR DESCRIPTION
## Summary
- make success messages green
- tweak favicon path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68460b2fc2308329a783a9bd62591aca