### PR TITLE
Fix input ref type mismatch

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -4,7 +4,7 @@ interface FileUploadProps {
   file: File | null;
   onFileChange: (file: File | null) => void;
   inputId: string;
-  inputRef?: React.RefObject<HTMLInputElement>;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
 }
 
 function FileUpload({ file, onFileChange, inputId, inputRef }: FileUploadProps) {


### PR DESCRIPTION
## Summary
- allow `FileUpload` to accept nullable input refs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68460d356fe883299d9f50c22e26783a